### PR TITLE
Fixed crash when app is still running but activity is destroyed

### DIFF
--- a/android/src/main/java/io/gjg/androidjobscheduler/AndroidJobScheduler.java
+++ b/android/src/main/java/io/gjg/androidjobscheduler/AndroidJobScheduler.java
@@ -57,7 +57,7 @@ public class AndroidJobScheduler extends JobService {
             return false;
         }
         Activity activity = ((FlutterApplication) context).getCurrentActivity();
-        return activity != null;
+        return activity != null && !activity.isDestroyed();
     }
 
     @Override


### PR DESCRIPTION
Steps to reproduce:
- run app, schedule event
- press back to minimize app, activity gets destroyed
- once job event fires, app crashes